### PR TITLE
Log errors on sync action - testConnection

### DIFF
--- a/src/run.php
+++ b/src/run.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Keboola\DbExtractor\Exception\UserException;
 use Keboola\DbExtractorLogger\Logger;
 use Keboola\DbExtractor\HiveApplication;
-use Monolog\Handler\NullHandler;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -42,7 +41,11 @@ try {
     $app = new HiveApplication($config, $logger, $inputState, $dataFolder);
 
     if ($app['action'] !== 'run') {
-        $app['logger']->setHandlers(array(new NullHandler(Logger::INFO)));
+        // On sync actions -> log only errors
+        $logger->setHandlers([
+            Logger::getDefaultCriticalHandler(),
+            Logger::getDefaultErrorHandler()->setLevel(Logger::ERROR),
+        ]);
         $runAction = false;
     }
 


### PR DESCRIPTION
Changes:
- Currenty, if is some error in testConnection action, no message is logged
- This PR implements support for log errors in sync action - testConnection
- It is similar to implementation in `php-component`: https://github.com/keboola/php-component/blob/f0b0a8f97e5ee4738ae3d7afd853288700e8430e/src/Logger.php#L50-L57