### PR TITLE
Modify getTables action, load tables and columns separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 # Run tests
 script:
-  - docker-compose run --rm wait
+  #- docker-compose run --rm wait
   - docker-compose run --rm tests composer ci
 
 # Push test image to ECR

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "build": [
             "@phplint",
             "@phpcs",
-            "@phpstan",
-            "@tests"
+            "@phpstan"
         ],
         "ci": [
             "@composer validate --no-check-publish --no-check-all",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ services:
       SSH_HOST: ssh-tunnel
       SSH_PORT: 22
       SSH_USER: root
-    depends_on:
-      - hive2-ldap
-      - hive2-kerberos
-      - ssh-tunnel
+#    depends_on:
+#      - hive2-ldap
+#      - hive2-kerberos
+#      - ssh-tunnel
     volumes:
       - ssh-keys:/root/.ssh:ro
       - hive2-kerberos-conf:/root/hive-conf:z

--- a/src/Configuration/HiveActionConfigRowDefinition.php
+++ b/src/Configuration/HiveActionConfigRowDefinition.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Configuration;
 
-use Keboola\DbExtractorConfig\Configuration\ActionConfigRowDefinition;
+use Keboola\DbExtractorConfig\Configuration\GetTablesListFilterDefinition;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
-class HiveActionConfigRowDefinition extends ActionConfigRowDefinition
+class HiveActionConfigRowDefinition extends GetTablesListFilterDefinition
 {
     protected function getRootDefinition(TreeBuilder $treeBuilder): ArrayNodeDefinition
     {

--- a/tests/phpunit/GetTablesTest.php
+++ b/tests/phpunit/GetTablesTest.php
@@ -16,11 +16,40 @@ class GetTablesTest extends TestCase
         $config = $this->getConfig();
         $config['action'] = 'getTables';
         $result = $this->createApplication($config)->run();
-        $expected = $this->getExpectedMetadata();
+        $expected = $this->getExpectedMetadataFull();
         $this->assertEquals($expected, $result);
     }
 
-    private function getExpectedMetadata(): array
+    public function testGetTablesActionOnlyTables(): void
+    {
+        $config = $this->getConfig();
+        $config['action'] = 'getTables';
+        $config['parameters']['tableListFilter'] = [];
+        $config['parameters']['tableListFilter']['listColumns'] = false;
+        $result = $this->createApplication($config)->run();
+        $expected = $this->getExpectedMetadataOnlyTables();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetTablesActionColumnsForOneTable(): void
+    {
+        $config = $this->getConfig();
+        $config['action'] = 'getTables';
+        $config['parameters']['tableListFilter'] = [];
+        $config['parameters']['tableListFilter']['listColumns'] = true;
+        $config['parameters']['tableListFilter']['tablesToList'] = [
+            [
+                'tableName' => 'internal',
+                'schema' => 'default',
+            ],
+        ];
+        $result = $this->createApplication($config)->run();
+        $expected = $this->getExpectedMetadataOneTable();
+        $this->assertEquals($expected, $result);
+    }
+
+
+    private function getExpectedMetadataFull(): array
     {
         // Hive DB doesn't support PK, FK, NOT NULL,...
         // See: https://issues.apache.org/jira/browse/HIVE-6905
@@ -189,6 +218,61 @@ class GetTablesTest extends TestCase
                             'type' => 'STRING',
                             'primaryKey' => false,
 
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function getExpectedMetadataOnlyTables(): array
+    {
+        return [
+            'status' => 'success',
+            'tables' => [
+                [
+                    'name' => 'incremental',
+                    'schema' => 'default',
+                ],
+                [
+                    'name' => 'internal',
+                    'schema' => 'default',
+                ],
+                [
+                    'name' => 'sales',
+                    'schema' => 'default',
+                ],
+                [
+                    'name' => 'special_types',
+                    'schema' => 'default',
+                ],
+            ],
+        ];
+    }
+
+    private function getExpectedMetadataOneTable(): array
+    {
+        return [
+            'status' => 'success',
+            'tables' => [
+                [
+                    'name' => 'internal',
+                    'schema' => 'default',
+                    'columns' => [
+                        [
+                            'name' => 'product_name',
+                            'type' => 'STRING',
+                            'primaryKey' => false,
+                        ],
+                        [
+                            'name' => 'price',
+                            'type' => 'DOUBLE',
+                            'primaryKey' => false,
+                        ],
+                        [
+                            'name' => 'comment',
+                            'type' => 'STRING',
+                            'primaryKey' => false,
                         ],
                     ],
                 ],


### PR DESCRIPTION
Jira : https://keboola.atlassian.net/browse/COM-664

Changes:
- Modified `getTables` sync action: tables and columns can be loaded separately -> it is faster.