### PR TITLE
Update db-extractor-common to latest version which fails when trying to set PK on non-existing column (case insensitive) and generate base types for custom quries

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,8 +23,8 @@ jobs:
         run: |
           docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
           docker build --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY -t $APP_IMAGE .
-          docker-compose run --rm wait
-          docker-compose run --rm tests composer ci
+          docker compose run --rm wait
+          docker compose run --rm tests composer ci
       - name: Push image to ECR
         run: |
           docker pull quay.io/keboola/developer-portal-cli-v2:latest

--- a/README.md
+++ b/README.md
@@ -183,15 +183,15 @@ git clone https://github.com/keboola/db-extractor-hive
 cd db-extractor-hive
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
-docker-compose build
-docker-compose run --rm wait
-docker-compose run --rm dev composer install --no-scripts
+docker compose build
+docker compose run --rm wait
+docker compose run --rm dev composer install --no-scripts
 ```
 
 Run the test suite using this command:
 
 ```
-docker-compose run --rm dev composer tests
+docker compose run --rm dev composer tests
 ```
  
 # Integration

--- a/composer.lock
+++ b/composer.lock
@@ -283,16 +283,16 @@
         },
         {
             "name": "keboola/db-extractor-common",
-            "version": "17.0.8",
+            "version": "17.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-common.git",
-                "reference": "2e2b8763c853938406e6cba64aeaf6760bdaddff"
+                "reference": "cd43ecb42f974f372da8350b12b11a85396b1cc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/2e2b8763c853938406e6cba64aeaf6760bdaddff",
-                "reference": "2e2b8763c853938406e6cba64aeaf6760bdaddff",
+                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/cd43ecb42f974f372da8350b12b11a85396b1cc3",
+                "reference": "cd43ecb42f974f372da8350b12b11a85396b1cc3",
                 "shasum": ""
             },
             "require": {
@@ -353,9 +353,9 @@
             ],
             "description": "Common library from Keboola Database Extractors",
             "support": {
-                "source": "https://github.com/keboola/db-extractor-common/tree/17.0.8"
+                "source": "https://github.com/keboola/db-extractor-common/tree/17.0.10"
             },
-            "time": "2024-07-23T09:18:14+00:00"
+            "time": "2024-08-15T08:43:34+00:00"
         },
         {
             "name": "keboola/db-extractor-config",
@@ -493,16 +493,16 @@
         },
         {
             "name": "keboola/php-component",
-            "version": "10.1.4",
+            "version": "10.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-component.git",
-                "reference": "ed4ddea277ceb443567e10204a5d86576d7ffe7a"
+                "reference": "9f8f43eb6077840cb648e12bedebd58d00667a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-component/zipball/ed4ddea277ceb443567e10204a5d86576d7ffe7a",
-                "reference": "ed4ddea277ceb443567e10204a5d86576d7ffe7a",
+                "url": "https://api.github.com/repos/keboola/php-component/zipball/9f8f43eb6077840cb648e12bedebd58d00667a5b",
+                "reference": "9f8f43eb6077840cb648e12bedebd58d00667a5b",
                 "shasum": ""
             },
             "require": {
@@ -547,22 +547,22 @@
             ],
             "support": {
                 "issues": "https://github.com/keboola/php-component/issues",
-                "source": "https://github.com/keboola/php-component/tree/10.1.4"
+                "source": "https://github.com/keboola/php-component/tree/10.1.5"
             },
-            "time": "2024-07-30T13:34:46+00:00"
+            "time": "2024-08-14T06:41:30+00:00"
         },
         {
             "name": "keboola/php-datatypes",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-datatypes.git",
-                "reference": "c869241a64de74c27a1f6b025cd6f3ee39034d38"
+                "reference": "cb3b828061c567a1abf490bb932d61f029d40b9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-datatypes/zipball/c869241a64de74c27a1f6b025cd6f3ee39034d38",
-                "reference": "c869241a64de74c27a1f6b025cd6f3ee39034d38",
+                "url": "https://api.github.com/repos/keboola/php-datatypes/zipball/cb3b828061c567a1abf490bb932d61f029d40b9e",
+                "reference": "cb3b828061c567a1abf490bb932d61f029d40b9e",
                 "shasum": ""
             },
             "require": {
@@ -595,9 +595,9 @@
             "description": "PHP datatypes for databases",
             "support": {
                 "issues": "https://github.com/keboola/php-datatypes/issues",
-                "source": "https://github.com/keboola/php-datatypes/tree/7.7.0"
+                "source": "https://github.com/keboola/php-datatypes/tree/7.8.0"
             },
-            "time": "2024-07-19T13:27:02+00:00"
+            "time": "2024-08-07T14:12:39+00:00"
         },
         {
             "name": "keboola/php-temp",
@@ -3107,16 +3107,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.40",
+            "version": "v5.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "f51cff4687547641c7d8180d74932ab40b2205ce"
+                "reference": "0724c51fa067b198e36506d2864e09a52180998a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/f51cff4687547641c7d8180d74932ab40b2205ce",
-                "reference": "f51cff4687547641c7d8180d74932ab40b2205ce",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0724c51fa067b198e36506d2864e09a52180998a",
+                "reference": "0724c51fa067b198e36506d2864e09a52180998a",
                 "shasum": ""
             },
             "require": {
@@ -3150,7 +3150,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.40"
+                "source": "https://github.com/symfony/finder/tree/v5.4.42"
             },
             "funding": [
                 {
@@ -3166,7 +3166,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:33:22+00:00"
+            "time": "2024-07-22T08:53:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3707,16 +3707,16 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.1.2",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "d7b91e4aa07e822a9b935fc29a7254c12d502f16"
+                "reference": "88a279df2db5b7919cac6f35d6a5d1d7147e6a9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/d7b91e4aa07e822a9b935fc29a7254c12d502f16",
-                "reference": "d7b91e4aa07e822a9b935fc29a7254c12d502f16",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/88a279df2db5b7919cac6f35d6a5d1d7147e6a9b",
+                "reference": "88a279df2db5b7919cac6f35d6a5d1d7147e6a9b",
                 "shasum": ""
             },
             "require": {
@@ -3771,7 +3771,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.1.2"
+                "source": "https://github.com/symfony/property-info/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -3787,20 +3787,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-26T07:21:35+00:00"
+            "time": "2024-07-26T07:36:36+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.9",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce"
+                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/56ce31d19127e79647ac53387c7555bdcd5730ce",
-                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/9a67fcf320561e96f94d62bbe0e169ac534a5718",
+                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718",
                 "shasum": ""
             },
             "require": {
@@ -3869,7 +3869,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.9"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -3885,20 +3885,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T07:59:05+00:00"
+            "time": "2024-07-26T13:13:26+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.2",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8"
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/14221089ac66cf82e3cf3d1c1da65de305587ff8",
-                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ea272a882be7f20cad58d5d78c215001617b7f07",
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07",
                 "shasum": ""
             },
             "require": {
@@ -3956,7 +3956,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.2"
+                "source": "https://github.com/symfony/string/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -3972,7 +3972,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:27:18+00:00"
+            "time": "2024-07-22T10:25:37+00:00"
         },
         {
             "name": "symfony/type-info",
@@ -4371,16 +4371,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.8",
+            "version": "1.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec"
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
                 "shasum": ""
             },
             "require": {
@@ -4425,7 +4425,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-24T07:01:22+00:00"
+            "time": "2024-08-08T09:02:50+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -283,16 +283,16 @@
         },
         {
             "name": "keboola/db-extractor-common",
-            "version": "17.0.10",
+            "version": "17.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-common.git",
-                "reference": "cd43ecb42f974f372da8350b12b11a85396b1cc3"
+                "reference": "851e30257adc3bc9b0d70f255a89a0e547eeee29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/cd43ecb42f974f372da8350b12b11a85396b1cc3",
-                "reference": "cd43ecb42f974f372da8350b12b11a85396b1cc3",
+                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/851e30257adc3bc9b0d70f255a89a0e547eeee29",
+                "reference": "851e30257adc3bc9b0d70f255a89a0e547eeee29",
                 "shasum": ""
             },
             "require": {
@@ -353,9 +353,9 @@
             ],
             "description": "Common library from Keboola Database Extractors",
             "support": {
-                "source": "https://github.com/keboola/db-extractor-common/tree/17.0.10"
+                "source": "https://github.com/keboola/db-extractor-common/tree/17.0.11"
             },
-            "time": "2024-08-15T08:43:34+00:00"
+            "time": "2024-09-02T08:58:42+00:00"
         },
         {
             "name": "keboola/db-extractor-config",
@@ -1293,35 +1293,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1330,7 +1330,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1359,7 +1359,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1367,7 +1367,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3107,16 +3107,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.42",
+            "version": "v5.4.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0724c51fa067b198e36506d2864e09a52180998a"
+                "reference": "ae25a9145a900764158d439653d5630191155ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0724c51fa067b198e36506d2864e09a52180998a",
-                "reference": "0724c51fa067b198e36506d2864e09a52180998a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ae25a9145a900764158d439653d5630191155ca0",
+                "reference": "ae25a9145a900764158d439653d5630191155ca0",
                 "shasum": ""
             },
             "require": {
@@ -3150,7 +3150,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.42"
+                "source": "https://github.com/symfony/finder/tree/v5.4.43"
             },
             "funding": [
                 {
@@ -3166,7 +3166,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-22T08:53:29+00:00"
+            "time": "2024-08-13T14:03:51+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3630,16 +3630,16 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v6.4.8",
+            "version": "v6.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "e4d9b00983612f9c0013ca37c61affdba2dd975a"
+                "reference": "866f6cd84f2094cbc6f66ce9752faf749916e2a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/e4d9b00983612f9c0013ca37c61affdba2dd975a",
-                "reference": "e4d9b00983612f9c0013ca37c61affdba2dd975a",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/866f6cd84f2094cbc6f66ce9752faf749916e2a9",
+                "reference": "866f6cd84f2094cbc6f66ce9752faf749916e2a9",
                 "shasum": ""
             },
             "require": {
@@ -3687,7 +3687,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v6.4.8"
+                "source": "https://github.com/symfony/property-access/tree/v6.4.11"
             },
             "funding": [
                 {
@@ -3703,7 +3703,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-08-30T16:10:11+00:00"
         },
         {
             "name": "symfony/property-info",
@@ -3791,16 +3791,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.10",
+            "version": "v6.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718"
+                "reference": "a75d03d7720417f8a654e73e8f02acdea8779cd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/9a67fcf320561e96f94d62bbe0e169ac534a5718",
-                "reference": "9a67fcf320561e96f94d62bbe0e169ac534a5718",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/a75d03d7720417f8a654e73e8f02acdea8779cd0",
+                "reference": "a75d03d7720417f8a654e73e8f02acdea8779cd0",
                 "shasum": ""
             },
             "require": {
@@ -3869,7 +3869,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.10"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.11"
             },
             "funding": [
                 {
@@ -3885,20 +3885,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-26T13:13:26+00:00"
+            "time": "2024-08-17T07:51:47+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.3",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07"
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ea272a882be7f20cad58d5d78c215001617b7f07",
-                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07",
+                "url": "https://api.github.com/repos/symfony/string/zipball/6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
                 "shasum": ""
             },
             "require": {
@@ -3956,7 +3956,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.3"
+                "source": "https://github.com/symfony/string/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -3972,7 +3972,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-22T10:25:37+00:00"
+            "time": "2024-08-12T09:59:40+00:00"
         },
         {
             "name": "symfony/type-info",
@@ -4324,16 +4324,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.29.1",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
+                "reference": "5ceb0e384997db59f38774bf79c2a6134252c08f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
-                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/5ceb0e384997db59f38774bf79c2a6134252c08f",
+                "reference": "5ceb0e384997db59f38774bf79c2a6134252c08f",
                 "shasum": ""
             },
             "require": {
@@ -4365,22 +4365,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.30.0"
             },
-            "time": "2024-05-31T08:52:43+00:00"
+            "time": "2024-08-29T09:54:52+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.10",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
+                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
-                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
+                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
                 "shasum": ""
             },
             "require": {
@@ -4425,7 +4425,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-08T09:02:50+00:00"
+            "time": "2024-08-27T09:18:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/tests/functional/query-join/expected/data/out/tables/in.c-main.sales.csv.manifest
+++ b/tests/functional/query-join/expected/data/out/tables/in.c-main.sales.csv.manifest
@@ -23,6 +23,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "usergender"
             },
@@ -39,6 +43,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -59,6 +67,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "INTEGER"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "usersentiment"
             },
@@ -75,6 +87,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -95,6 +111,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "sku"
             },
@@ -111,6 +131,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -131,6 +155,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "category"
             },
@@ -147,6 +175,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "FLOAT"
             },
             {
                 "key": "KBC.sourceName",
@@ -167,6 +199,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "county"
             },
@@ -183,6 +219,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -203,6 +243,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "userstate"
             },
@@ -221,6 +265,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "categorygroup"
             },
@@ -237,6 +285,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "FLOAT"
             },
             {
                 "key": "KBC.sourceName",

--- a/tests/functional/query-simple-1/expected/data/out/tables/in.c-main.tables.csv.manifest
+++ b/tests/functional/query-simple-1/expected/data/out/tables/in.c-main.tables.csv.manifest
@@ -11,6 +11,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "tab_name"
             },

--- a/tests/functional/query-simple/expected/data/out/tables/in.c-main.sales.csv.manifest
+++ b/tests/functional/query-simple/expected/data/out/tables/in.c-main.sales.csv.manifest
@@ -22,6 +22,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "usergender"
             },
@@ -38,6 +42,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -58,6 +66,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "INTEGER"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "usersentiment"
             },
@@ -74,6 +86,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -94,6 +110,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "sku"
             },
@@ -110,6 +130,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -130,6 +154,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "category"
             },
@@ -146,6 +174,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "FLOAT"
             },
             {
                 "key": "KBC.sourceName",
@@ -166,6 +198,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "county"
             },
@@ -182,6 +218,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",
@@ -202,6 +242,10 @@
                 "value": true
             },
             {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "userstate"
             },
@@ -218,6 +262,10 @@
             {
                 "key": "KBC.datatype.nullable",
                 "value": true
+            },
+            {
+                "key": "KBC.datatype.basetype",
+                "value": "STRING"
             },
             {
                 "key": "KBC.sourceName",


### PR DESCRIPTION
<img width="789" alt="Snímek obrazovky 2024-08-14 v 16 13 56" src="https://github.com/user-attachments/assets/33ad720d-4fd7-4aa4-a082-57e313973e68">

JIRA: 
- https://keboola.atlassian.net/browse/PST-1996
- https://keboola.atlassian.net/browse/PST-2025

SLACK: https://keboolaglobal.slack.com/archives/C055HSMKX51/p1723642181597589?thread_ts=1723214328.361609&cid=C055HSMKX51