### PR TITLE
SUPPORT-11491: feat: raise the maximum string column length 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,9 +85,9 @@ RUN dpkg -i /tmp/hive-odbc.deb || true \
     && cp /opt/cloudera/hiveodbc/Setup/odbc.ini   /etc/odbc.ini \
     && cp /opt/cloudera/hiveodbc/Setup/odbcinst.ini /etc/odbcinst.ini \
     # Set default maximum string column length for Hive ODBC (DSN-level)
-    && sed -i '/^\[/a DefaultStringColumnLength = 16777216' /etc/odbc.ini \
+    && sed -i '/^\[/a DefaultStringColumnLength = 134217728' /etc/odbc.ini \
     # Set default maximum string column length for Hive ODBC (driver-level)
-    && sed -i '/^\[Cloudera ODBC Driver for Apache Hive 64-bit\]/a DefaultStringColumnLength = 16777216' /etc/odbcinst.ini
+    && sed -i '/^\[Cloudera ODBC Driver for Apache Hive 64-bit\]/a DefaultStringColumnLength = 134217728' /etc/odbcinst.ini
 
 # Create odbc logs dir
 RUN mkdir -p /var/log/hive-odbc \

--- a/src/Connection/HiveDsnFactory.php
+++ b/src/Connection/HiveDsnFactory.php
@@ -27,9 +27,9 @@ class HiveDsnFactory
         $parameters['Port'] = $dbConfig->getPort();
         $parameters['Schema'] = $dbConfig->getDatabase();
         $parameters['UseNativeQuery'] = '1';
-        $parameters['DefaultStringColumnLength'] = '16777216';
-        $parameters['DefaultVarcharColumnLength'] = '16777216';
-        $parameters['BinaryColumnLength'] = '16777216';
+        $parameters['DefaultStringColumnLength'] = '134217728';
+        $parameters['DefaultVarcharColumnLength'] = '134217728';
+        $parameters['BinaryColumnLength'] = '134217728';
         $parameters['UseUnicodeSqlCharacterTypes'] = '1';
         $parameters['KeepAlive'] = '1';
         $parameters['RowsFetchedPerBlock'] = $dbConfig->getBatchSize();

--- a/src/Extractor/HiveOdbcQueryResult.php
+++ b/src/Extractor/HiveOdbcQueryResult.php
@@ -23,7 +23,7 @@ class HiveOdbcQueryResult extends OdbcQueryResult implements QueryResult
         $row = null;
         $numCols = odbc_num_fields($this->stmt);
 
-        odbc_longreadlen($this->stmt, 33554432);
+        odbc_longreadlen($this->stmt, 134217728);
         odbc_binmode($this->stmt, ODBC_BINMODE_RETURN);
 
         if (odbc_fetch_row($this->stmt)) {

--- a/tests/functional/kerberos-con-through/expected-stdout
+++ b/tests/functional/kerberos-con-through/expected-stdout
@@ -1,7 +1,7 @@
 Connect through is enabled, DelegationUID = "my-realuser".
 Starting Kerberos "kinit" authentication as "hive/localhost".
 Kerberos authentication successful.
-Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;DelegationUID=my-realuser;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=1;CAIssuedCertNamesMismatch=0;".
+Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;DelegationUID=my-realuser;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=1;CAIssuedCertNamesMismatch=0;".
 Exporting to "in.c-main.internal".
 Exported "2" rows to "in.c-main.internal".
 Hive extractor finished.

--- a/tests/functional/kerberos-table-full/expected-stdout
+++ b/tests/functional/kerberos-table-full/expected-stdout
@@ -1,6 +1,6 @@
 Starting Kerberos "kinit" authentication as "hive/localhost".
 Kerberos authentication successful.
-Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
+Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
 Exporting to "in.c-main.internal".
 Exported "2" rows to "in.c-main.internal".
 Hive extractor finished.

--- a/tests/functional/stack-parameters-overwrite-run/expected-stdout
+++ b/tests/functional/stack-parameters-overwrite-run/expected-stdout
@@ -1,6 +1,6 @@
 Starting Kerberos "kinit" authentication as "hive/localhost".
 Kerberos authentication successful.
-Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
+Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
 Exporting to "in.c-main.internal".
 Exported "2" rows to "in.c-main.internal".
 Hive extractor finished.

--- a/tests/functional/stack-parameters-run/expected-stdout
+++ b/tests/functional/stack-parameters-run/expected-stdout
@@ -1,6 +1,6 @@
 Starting Kerberos "kinit" authentication as "hive/localhost".
 Kerberos authentication successful.
-Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
+Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-kerberos;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=hive;KrbRealm=KEBOOLA.COM;SSL=1;AllowSelfSignedServerCert=0;CAIssuedCertNamesMismatch=0;TrustedCerts=/tmp/%A/ca-bundle.pem;".
 Exporting to "in.c-main.internal".
 Exported "2" rows to "in.c-main.internal".
 Hive extractor finished.

--- a/tests/functional/table-full-debug-mode/expected-stdout
+++ b/tests/functional/table-full-debug-mode/expected-stdout
@@ -1,5 +1,5 @@
 [%s] DEBUG: Component initialization completed [] []
-Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-ldap;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=3;".
+Creating ODBC connection to "Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=hive2-ldap;Port=10000;Schema=default;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;AuthMech=3;".
 [%s] DEBUG: Running query "set hive.resultset.use.unique.column.names=false". [] []
 Exporting to "in.c-main.internal".
 [%s] DEBUG: Running query "SELECT    *  FROM    `default`.`internal`". [] []

--- a/tests/phpunit/HiveDsnFactoryTest.php
+++ b/tests/phpunit/HiveDsnFactoryTest.php
@@ -76,8 +76,8 @@ class HiveDsnFactoryTest extends TestCase
                 '#password' => '123',
             ],
             'Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=test-host.com;Port=123;' .
-            'Schema=my-db;UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;'.
-            'BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
+            'Schema=my-db;UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;'.
+            'BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
             'RowsFetchedPerBlock=10000;AuthMech=3;',
         ];
 
@@ -95,8 +95,8 @@ class HiveDsnFactoryTest extends TestCase
                 ],
                 ],
                 'Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=test-host.com;Port=123;Schema=my-db;'.
-                'UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;'.
-                'BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;'.
+                'UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;'.
+                'BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;'.
                 'AuthMech=1;KrbHostFQDN=localhost;KrbServiceName=service;KrbRealm=EXAMPLE.COM;',
         ];
 
@@ -111,8 +111,8 @@ class HiveDsnFactoryTest extends TestCase
                 'batchSize' => 3000,
             ],
             'Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=test-host.com;Port=123;Schema=my-db;'.
-            'UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;'.
-            'BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
+            'UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;'.
+            'BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
             'RowsFetchedPerBlock=3000;AuthMech=3;',
         ];
 
@@ -127,8 +127,8 @@ class HiveDsnFactoryTest extends TestCase
                 'verboseLogging' => true,
             ],
             'Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=test-host.com;Port=123;Schema=my-db;'.
-            'UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;'.
-            'BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
+            'UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;'.
+            'BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;'.
             'RowsFetchedPerBlock=10000;LogLevel=6;'.
             'LogPath=/var/log/cloudera-odbc/;AuthMech=3;',
         ];
@@ -145,8 +145,8 @@ class HiveDsnFactoryTest extends TestCase
                 'httpPath' => 'gateway/XXXXX/hive',
             ],
             'Driver=Cloudera ODBC Driver for Apache Hive 64-bit;Host=test-host.com;Port=123;Schema=my-db;'.
-            'UseNativeQuery=1;DefaultStringColumnLength=16777216;DefaultVarcharColumnLength=16777216;'.
-            'BinaryColumnLength=16777216;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;'.
+            'UseNativeQuery=1;DefaultStringColumnLength=134217728;DefaultVarcharColumnLength=134217728;'.
+            'BinaryColumnLength=134217728;UseUnicodeSqlCharacterTypes=1;KeepAlive=1;RowsFetchedPerBlock=10000;'.
             'ThriftTransport=2;HttpPath=gateway/XXXXX/hive;AuthMech=3;',
         ];
     }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SUPPORT-11491

Follow up to https://github.com/keboola/db-extractor-hive/pull/44.
The limits raised even further.

- feat: raise the maximum string column length to maximum Snowflake supported lenght 134217728

# Release notes

## Plans for customer communication
Inform #customer_success channel mainly CSAS and Groupon.

## Impact analysis
Mainly used in CSAS and Groupon
<img width="964" height="462" alt="Screenshot 2025-08-04 at 14 25 22" src="https://github.com/user-attachments/assets/91495f26-4af7-4008-ac6e-b23fc125fd4b" />

The component has been tested for a while now in CSAS. See support ticket.

## Change type
Improvement. Raise the maximum limits for long string fields.

## Justification
It's now better compatible with Snowflake string types (length). Before it wasn't possible to import longer strings.

## Deployment
Merge & automatic deploy.

## Rollback plan
Change to previous version in Dev portal.

## Post release support plan
Monitor errors from the component.