### PR TITLE
chore: upgrade base image to Debian Trixie (php:8.2-cli-trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN aws s3 cp \
       s3://keboola-drivers/hive-odbc/clouderahiveodbc_2.8.2.1002-2_amd64.deb \
       /tmp/hive-odbc.deb
 
-FROM php:8.2-cli-bullseye
+FROM php:8.2-cli-trixie
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,11 @@ RUN curl -fSL "$HIVE_ODBC_DEB_URL" -o /tmp/hive-odbc.deb \
     && apt-get install -f -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm /tmp/hive-odbc.deb \
+    # The driver ships DriverManagerEncoding=UTF-32 (the iODBC default). The driver manager here is
+    # unixODBC, whose SQLWCHAR is 2 bytes (UTF-16) on Debian; the mismatch makes the driver read/write
+    # wide-char strings at the wrong width on connect, overflowing a buffer. It went unnoticed on
+    # bullseye but Trixie's hardened glibc traps it ("*** stack smashing detected ***"). Match unixODBC.
+    && sed -i 's/^DriverManagerEncoding=.*/DriverManagerEncoding=UTF-16/' /opt/cloudera/hiveodbc/lib/64/cloudera.hiveodbc.ini \
     && cp /opt/cloudera/hiveodbc/Setup/odbc.ini   /etc/odbc.ini \
     && cp /opt/cloudera/hiveodbc/Setup/odbcinst.ini /etc/odbcinst.ini \
     # Set default maximum string column length for Hive ODBC (DSN-level)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
-FROM amazon/aws-cli:2.13.0 AS awscli
-
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ARG AWS_REGION=eu-central-1
-ENV AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
-    AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
-    AWS_DEFAULT_REGION=${AWS_REGION}   \
-    AWS_REGION=${AWS_REGION}
-
-RUN aws s3 cp \
-      s3://keboola-drivers/hive-odbc/clouderahiveodbc_2.8.2.1002-2_amd64.deb \
-      /tmp/hive-odbc.deb
-
 FROM php:8.2-cli-trixie
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
+# Cloudera Hive ODBC driver, fetched at build time from Cloudera's public CDN (the authoritative
+# source the keboola-drivers S3 bucket mirrors). 2.9.0.1001 is the first build that officially
+# supports Debian 13 (Trixie); the previous 2.8.2 connects but stack-smashes on query execution
+# under Trixie's hardened glibc. To pin a different build, override HIVE_ODBC_VERSION.
+ARG HIVE_ODBC_VERSION=2.9.0.1001
+ARG HIVE_ODBC_DEB_URL=https://downloads.cloudera.com/connectors/ClouderaHiveODBC-${HIVE_ODBC_VERSION}/Debian/clouderahiveodbc_${HIVE_ODBC_VERSION}-2_amd64.deb
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_PROCESS_TIMEOUT 3600
 
@@ -29,6 +21,8 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update && apt-get install -y --no-install-recommends \
         ssh \
         git \
+        curl \
+        ca-certificates \
         locales \
         unzip \
         unixodbc \
@@ -76,8 +70,8 @@ RUN set -ex; \
     docker-php-source delete
 
 # Cloudera Hive Driver
-COPY --from=awscli /tmp/hive-odbc.deb /tmp/hive-odbc.deb
-RUN dpkg -i /tmp/hive-odbc.deb || true \
+RUN curl -fSL "$HIVE_ODBC_DEB_URL" -o /tmp/hive-odbc.deb \
+    && { dpkg -i /tmp/hive-odbc.deb || true; } \
     && apt-get update \
     && apt-get install -f -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
   # Test cmd: docker-compose exec ldap ldapsearch -x -H ldap://localhost -b dc=keboola-test,dc=com -D "uid=admin,dc=keboola-test,dc=com" -w 'admin'
   # Modify command: docker-compose exec ldap ldapmodify -H ldap://localhost -D "uid=admin,dc=keboola-test,dc=com" -w 'admin'
   ldap:
-    image: osixia/openldap:1.3.0-amd64
+    image: osixia/openldap:1.3.0
     command: --copy-service
     environment:
       LDAP_TLS: 'false'


### PR DESCRIPTION
## What

Upgrades the component base image from **Debian bullseye to Debian Trixie** (`php:8.2-cli-bullseye` → `php:8.2-cli-trixie`), keeping PHP 8.2, and resolves the ODBC incompatibilities that surfaced.

Independent of the incremental-fetching work (#51) — branched off `master`.

## Incompatibilities found and fixed

1. **The old Cloudera Hive ODBC driver stack-smashed on Trixie.** The pinned `2.8.2.1002` connected but aborted at the first query/connect with `*** stack smashing detected ***` (SIGABRT, exit 134) under Trixie's hardened glibc 2.41.
   - **Root cause:** the driver ships `DriverManagerEncoding=UTF-32` (the iODBC default), but the PHP `odbc` extension's driver manager is **unixODBC**, whose `SQLWCHAR` is 2 bytes / **UTF-16** on Debian (verified by compiling against the headers on both bullseye and Trixie). The driver therefore read/wrote wide-char connection strings at the wrong width, overflowing a stack buffer. It was silently latent on bullseye (glibc 2.31); Trixie's glibc traps it.
   - **Fix:** set `DriverManagerEncoding=UTF-16` in the driver's `cloudera.hiveodbc.ini` to match unixODBC. **This is the change that actually unblocks Trixie** — bumping the driver version alone did not.
2. **Driver bumped to `2.9.0.1001`** — the first Cloudera build that officially lists Debian 11/12/**13** support (2.8.2 predates Debian 13). Its deps are modern and satisfiable (`libc6`/`libgcc1`/`libstdc++6`/`libsasl2-modules-gssapi-mit`; no `libssl1.1`).
3. **Driver now fetched from Cloudera's public CDN** (`downloads.cloudera.com`, the authoritative source the `keboola-drivers` S3 bucket mirrors), pinned via the `HIVE_ODBC_VERSION` build arg. This **removes the AWS-credentials build requirement** — the `amazon/aws-cli` S3 stage is gone. `curl` + `ca-certificates` were added for the download.
4. **LDAP test image repin** (`osixia/openldap:1.3.0-amd64` → `1.3.0`) — Docker Hub dropped the arch-specific tag, which was breaking `docker compose build` for all hive CI. Same version, multi-arch tag. *(Also present on #51; identical one-liner.)*

Everything else on Trixie worked unchanged: the full apt set resolves, the `libiodbcinst.so` symlink resolves, and the `intl`/`zip`/`odbc` extensions build.

## Verification

- **CI green** on the full `composer ci` (validate + phplint + **phpcs + phpstan level max + phpunit + datadir**) against the live hive2 (LDAP + Kerberos) harness — the datadir/phpunit suites connect and run real queries through the driver, so the stack-smash is confirmed gone.
- The full component image also builds locally on Trixie (the driver package is `Architecture: all`, so it installs on any arch), independent of CI.

## Notes for reviewers

- **Driver source (S3 vs CDN):** this fetches the driver from Cloudera's public CDN instead of the S3 mirror. If you'd rather keep mirroring, upload `clouderahiveodbc_2.9.0.1001-2_amd64.deb` to `keboola-drivers/hive-odbc/` and repoint the `curl` to it (a one-line change) — happy to do that if preferred.
- The `--build-arg AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in `push.yml` and `docker-compose.yml` are now unused (harmless — Docker just warns). Can be dropped in a follow-up.
- `odbcinst`/`isql` CLIs aren't packaged on Trixie's `unixodbc`, but the component doesn't use them (it uses the PHP `odbc` extension against `libodbc`, present via `unixodbc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
